### PR TITLE
Fix repo name when origin is missing `.git` extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,10 @@ repo.sync = (options = {}) => {
 };
 
 function stem(filepath) {
-  return path.basename(filepath, path.extname(filepath));
+  const ext = path.extname(filepath);
+  return ext === '.git'
+   ? path.basename(filepath, ext)
+   : path.basename(filepath);
 }
 
 module.exports = repo;


### PR DESCRIPTION
This fixes an issue when a repository is cloned without the `.git` suffix, for example `git clone https://github.com/styfle/git-repo-name.js`, and the name being reported was `git-repo-name` instead of the expected `git-repo-name.js`.

Fixes #4 

